### PR TITLE
feat: CSV/Excelエクスポート機能を実装

### DIFF
--- a/app/(admin)/admin/export/page.tsx
+++ b/app/(admin)/admin/export/page.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import { useState } from "react";
+import { useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
+import { Download, FileSpreadsheet, FileText, Calendar, Loader2 } from "lucide-react";
+import { useToast, ToastContainer } from "@/components/ui/toast";
+
+type ExportType = "licenses" | "vehicles" | "insurance" | "history" | "all";
+type ExportFormat = "csv" | "xlsx";
+
+export default function ExportPage() {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+  const toast = useToast();
+
+  const [exportType, setExportType] = useState<ExportType>("all");
+  const [exportFormat, setExportFormat] = useState<ExportFormat>("xlsx");
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  // 未認証の場合はログインページにリダイレクト
+  if (status === "unauthenticated") {
+    router.push("/auth/signin");
+    return null;
+  }
+
+  if (status === "loading") {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
+          <p className="mt-4 text-gray-600">読み込み中...</p>
+        </div>
+      </div>
+    );
+  }
+
+  const handleExport = async () => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({
+        type: exportType,
+        format: exportFormat,
+      });
+
+      if (startDate) params.append("startDate", startDate);
+      if (endDate) params.append("endDate", endDate);
+
+      const response = await fetch(`/api/export?${params.toString()}`);
+
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.error || "エクスポートに失敗しました");
+      }
+
+      // ファイルをダウンロード
+      const blob = await response.blob();
+      const contentDisposition = response.headers.get("Content-Disposition");
+      let filename = `export.${exportFormat}`;
+
+      if (contentDisposition) {
+        const match = contentDisposition.match(/filename="(.+)"/);
+        if (match) {
+          filename = decodeURIComponent(match[1]);
+        }
+      }
+
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      window.URL.revokeObjectURL(url);
+      document.body.removeChild(a);
+
+      toast.success("エクスポートが完了しました");
+    } catch (error) {
+      console.error("Export error:", error);
+      toast.error(error instanceof Error ? error.message : "エクスポートに失敗しました");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const exportTypes: { value: ExportType; label: string; description: string }[] = [
+    { value: "all", label: "全データ", description: "免許証・車検証・保険証・承認履歴の全て" },
+    { value: "licenses", label: "免許証", description: "運転免許証の登録データ" },
+    { value: "vehicles", label: "車検証", description: "車検証の登録データ" },
+    { value: "insurance", label: "保険証", description: "任意保険の登録データ" },
+    { value: "history", label: "承認履歴", description: "承認・却下の履歴データ" },
+  ];
+
+  return (
+    <div className="p-4 sm:p-8 max-w-4xl mx-auto">
+      {/* ページヘッダー */}
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
+          <Download className="h-7 w-7" />
+          データエクスポート
+        </h1>
+        <p className="mt-2 text-gray-600">
+          申請データや承認履歴をCSV/Excel形式でダウンロードできます
+        </p>
+      </div>
+
+      <div className="bg-white rounded-lg shadow p-6 space-y-6">
+        {/* エクスポート対象 */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-3">
+            エクスポート対象
+          </label>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            {exportTypes.map((type) => (
+              <button
+                key={type.value}
+                onClick={() => setExportType(type.value)}
+                className={`p-4 rounded-lg border-2 text-left transition-colors ${
+                  exportType === type.value
+                    ? "border-blue-500 bg-blue-50"
+                    : "border-gray-200 hover:border-gray-300"
+                }`}
+              >
+                <div className="font-medium text-gray-900">{type.label}</div>
+                <div className="text-xs text-gray-500 mt-1">{type.description}</div>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* ファイル形式 */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-3">
+            ファイル形式
+          </label>
+          <div className="flex gap-4">
+            <button
+              onClick={() => setExportFormat("xlsx")}
+              className={`flex items-center gap-2 px-4 py-3 rounded-lg border-2 transition-colors ${
+                exportFormat === "xlsx"
+                  ? "border-green-500 bg-green-50"
+                  : "border-gray-200 hover:border-gray-300"
+              }`}
+            >
+              <FileSpreadsheet className="h-5 w-5 text-green-600" />
+              <div>
+                <div className="font-medium">Excel (.xlsx)</div>
+                <div className="text-xs text-gray-500">複数シート対応</div>
+              </div>
+            </button>
+            <button
+              onClick={() => setExportFormat("csv")}
+              className={`flex items-center gap-2 px-4 py-3 rounded-lg border-2 transition-colors ${
+                exportFormat === "csv"
+                  ? "border-blue-500 bg-blue-50"
+                  : "border-gray-200 hover:border-gray-300"
+              }`}
+            >
+              <FileText className="h-5 w-5 text-blue-600" />
+              <div>
+                <div className="font-medium">CSV (.csv)</div>
+                <div className="text-xs text-gray-500">単一シート</div>
+              </div>
+            </button>
+          </div>
+        </div>
+
+        {/* 日付フィルター（履歴のみ） */}
+        {(exportType === "history" || exportType === "all") && (
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-3">
+              <Calendar className="h-4 w-4 inline mr-1" />
+              日付範囲（承認履歴のフィルター）
+            </label>
+            <div className="flex flex-wrap gap-4">
+              <div>
+                <label className="block text-xs text-gray-500 mb-1">開始日</label>
+                <input
+                  type="date"
+                  value={startDate}
+                  onChange={(e) => setStartDate(e.target.value)}
+                  className="border rounded-lg px-3 py-2 text-sm"
+                />
+              </div>
+              <div>
+                <label className="block text-xs text-gray-500 mb-1">終了日</label>
+                <input
+                  type="date"
+                  value={endDate}
+                  onChange={(e) => setEndDate(e.target.value)}
+                  className="border rounded-lg px-3 py-2 text-sm"
+                />
+              </div>
+              {(startDate || endDate) && (
+                <button
+                  onClick={() => {
+                    setStartDate("");
+                    setEndDate("");
+                  }}
+                  className="self-end px-3 py-2 text-sm text-gray-600 hover:text-gray-800"
+                >
+                  クリア
+                </button>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* エクスポートボタン */}
+        <div className="pt-4 border-t">
+          <button
+            onClick={handleExport}
+            disabled={loading}
+            className="w-full sm:w-auto px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+          >
+            {loading ? (
+              <>
+                <Loader2 className="h-5 w-5 animate-spin" />
+                エクスポート中...
+              </>
+            ) : (
+              <>
+                <Download className="h-5 w-5" />
+                エクスポート実行
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+
+      {/* 注意事項 */}
+      <div className="mt-6 bg-yellow-50 border border-yellow-200 rounded-lg p-4">
+        <h3 className="font-medium text-yellow-800 mb-2">注意事項</h3>
+        <ul className="text-sm text-yellow-700 space-y-1 list-disc list-inside">
+          <li>エクスポートされたデータには個人情報が含まれます。取り扱いにご注意ください。</li>
+          <li>CSV形式はUTF-8（BOM付き）で出力されます。Excelで開く場合は文字化けしません。</li>
+          <li>Excel形式では、データ種別ごとに別シートで出力されます。</li>
+        </ul>
+      </div>
+
+      <ToastContainer toasts={toast.toasts} onClose={toast.removeToast} />
+    </div>
+  );
+}

--- a/app/api/export/route.ts
+++ b/app/api/export/route.ts
@@ -1,0 +1,232 @@
+import { NextRequest, NextResponse } from "next/server";
+import * as XLSX from "xlsx";
+import { requireAdmin } from "@/lib/auth-utils";
+import { getDriversLicenses } from "@/services/drivers-license.service";
+import { getVehicleRegistrations } from "@/services/vehicle-registration.service";
+import { getInsurancePolicies } from "@/services/insurance-policy.service";
+import { getApprovalHistory } from "@/services/approval-history.service";
+
+type ExportType = "licenses" | "vehicles" | "insurance" | "history" | "all";
+type ExportFormat = "csv" | "xlsx";
+
+interface ExportOptions {
+  type: ExportType;
+  format: ExportFormat;
+  startDate?: string;
+  endDate?: string;
+}
+
+/**
+ * 日付をフォーマット
+ */
+function formatDate(date: Date | string | number | undefined): string {
+  if (!date) return "";
+  const d = new Date(date);
+  if (isNaN(d.getTime())) return "";
+  return d.toLocaleDateString("ja-JP");
+}
+
+/**
+ * 承認ステータスを日本語に変換
+ */
+function formatStatus(status: string): string {
+  switch (status) {
+    case "approved": return "承認済み";
+    case "pending": return "審査中";
+    case "rejected": return "却下";
+    default: return status;
+  }
+}
+
+/**
+ * 免許証データを変換
+ */
+async function getLicenseData() {
+  const licenses = await getDriversLicenses();
+  return licenses.map(license => ({
+    "社員ID": license.employee_id,
+    "免許番号": license.license_number,
+    "有効期限": formatDate(license.expiration_date),
+    "承認状態": formatStatus(license.approval_status),
+    "却下理由": license.rejection_reason || "",
+    "登録日": formatDate(license.created_at),
+    "更新日": formatDate(license.updated_at),
+  }));
+}
+
+/**
+ * 車両データを変換
+ */
+async function getVehicleData() {
+  const vehicles = await getVehicleRegistrations();
+  return vehicles.map(vehicle => ({
+    "社員ID": vehicle.employee_id,
+    "車両番号": vehicle.vehicle_number,
+    "メーカー": vehicle.manufacturer,
+    "車名": vehicle.model_name,
+    "車検有効期限": formatDate(vehicle.inspection_expiration_date),
+    "承認状態": formatStatus(vehicle.approval_status),
+    "却下理由": vehicle.rejection_reason || "",
+    "登録日": formatDate(vehicle.created_at),
+  }));
+}
+
+/**
+ * 保険データを変換
+ */
+async function getInsuranceData() {
+  const insurances = await getInsurancePolicies();
+  return insurances.map(insurance => ({
+    "社員ID": insurance.employee_id,
+    "証券番号": insurance.policy_number,
+    "保険会社": insurance.insurance_company || "",
+    "補償開始日": formatDate(insurance.coverage_start_date),
+    "補償終了日": formatDate(insurance.coverage_end_date),
+    "対人賠償（無制限）": insurance.liability_personal_unlimited ? "はい" : "いいえ",
+    "対物賠償（万円）": insurance.liability_property_amount || "",
+    "搭乗者傷害（万円）": insurance.passenger_injury_amount || "",
+    "承認状態": formatStatus(insurance.approval_status),
+    "登録日": formatDate(insurance.created_at),
+  }));
+}
+
+/**
+ * 承認履歴データを変換
+ */
+async function getHistoryData(startDate?: string, endDate?: string) {
+  const history = await getApprovalHistory();
+
+  let filtered = history;
+  if (startDate) {
+    const start = new Date(startDate).getTime();
+    filtered = filtered.filter(h => h.timestamp >= start);
+  }
+  if (endDate) {
+    const end = new Date(endDate).getTime() + 86400000; // 終了日の翌日まで
+    filtered = filtered.filter(h => h.timestamp < end);
+  }
+
+  return filtered.map(record => ({
+    "日時": formatDate(record.timestamp),
+    "社員ID": record.employee_id,
+    "社員名": record.employee_name,
+    "書類種別": record.application_type === "license" ? "免許証" :
+               record.application_type === "vehicle" ? "車検証" : "保険証",
+    "アクション": record.action === "approved" ? "承認" : "却下",
+    "承認者ID": record.approver_id,
+    "承認者名": record.approver_name,
+    "却下理由": record.reason || "",
+  }));
+}
+
+/**
+ * ワークブックを作成
+ */
+function createWorkbook(data: Record<string, any[]>): XLSX.WorkBook {
+  const wb = XLSX.utils.book_new();
+
+  for (const [sheetName, sheetData] of Object.entries(data)) {
+    if (sheetData.length > 0) {
+      const ws = XLSX.utils.json_to_sheet(sheetData);
+
+      // 列幅を自動調整
+      const colWidths = Object.keys(sheetData[0]).map(key => ({
+        wch: Math.max(key.length * 2, 12)
+      }));
+      ws["!cols"] = colWidths;
+
+      XLSX.utils.book_append_sheet(wb, ws, sheetName);
+    }
+  }
+
+  return wb;
+}
+
+/**
+ * GET /api/export
+ * データをCSV/Excel形式でエクスポート
+ */
+export async function GET(request: NextRequest) {
+  // 管理者権限チェック
+  const authCheck = await requireAdmin();
+  if (!authCheck.authorized) {
+    return authCheck.response;
+  }
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const type = (searchParams.get("type") || "all") as ExportType;
+    const format = (searchParams.get("format") || "xlsx") as ExportFormat;
+    const startDate = searchParams.get("startDate") || undefined;
+    const endDate = searchParams.get("endDate") || undefined;
+
+    // データを取得
+    const data: Record<string, any[]> = {};
+
+    if (type === "licenses" || type === "all") {
+      data["免許証"] = await getLicenseData();
+    }
+    if (type === "vehicles" || type === "all") {
+      data["車検証"] = await getVehicleData();
+    }
+    if (type === "insurance" || type === "all") {
+      data["保険証"] = await getInsuranceData();
+    }
+    if (type === "history" || type === "all") {
+      data["承認履歴"] = await getHistoryData(startDate, endDate);
+    }
+
+    // 空データチェック
+    const totalRecords = Object.values(data).reduce((sum, arr) => sum + arr.length, 0);
+    if (totalRecords === 0) {
+      return NextResponse.json(
+        { success: false, error: "エクスポートするデータがありません" },
+        { status: 404 }
+      );
+    }
+
+    // ワークブック作成
+    const wb = createWorkbook(data);
+
+    // ファイル名生成
+    const timestamp = new Date().toISOString().slice(0, 10);
+    const typeLabel = type === "all" ? "全データ" :
+                      type === "licenses" ? "免許証" :
+                      type === "vehicles" ? "車検証" :
+                      type === "insurance" ? "保険証" : "承認履歴";
+    const filename = `${typeLabel}_${timestamp}.${format}`;
+
+    if (format === "csv") {
+      // CSVの場合は最初のシートのみ
+      const firstSheet = Object.keys(data)[0];
+      const csv = XLSX.utils.sheet_to_csv(wb.Sheets[firstSheet]);
+
+      // BOM付きUTF-8でCSV出力（日本語文字化け対策）
+      const bom = "\uFEFF";
+      const csvWithBom = bom + csv;
+
+      return new NextResponse(csvWithBom, {
+        headers: {
+          "Content-Type": "text/csv; charset=utf-8",
+          "Content-Disposition": `attachment; filename="${encodeURIComponent(filename)}"`,
+        },
+      });
+    } else {
+      // Excel形式
+      const buffer = XLSX.write(wb, { type: "buffer", bookType: "xlsx" });
+
+      return new NextResponse(buffer, {
+        headers: {
+          "Content-Type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "Content-Disposition": `attachment; filename="${encodeURIComponent(filename)}"`,
+        },
+      });
+    }
+  } catch (error) {
+    console.error("Export error:", error);
+    return NextResponse.json(
+      { success: false, error: "エクスポートに失敗しました" },
+      { status: 500 }
+    );
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "react-zoom-pan-pinch": "^3.7.0",
         "tailwind-merge": "^3.4.0",
         "tailwindcss-animate": "^1.0.7",
+        "xlsx": "^0.18.5",
         "zod": "^4.2.1"
       },
       "devDependencies": {
@@ -5399,6 +5400,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -6135,6 +6145,19 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -6260,6 +6283,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -6335,6 +6367,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/cross-spawn": {
@@ -7731,6 +7775,15 @@
       "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
       "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
       "license": "MIT"
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/fraction.js": {
       "version": "5.3.4",
@@ -11293,6 +11346,18 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
@@ -12786,6 +12851,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -12847,6 +12930,27 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react-zoom-pan-pinch": "^3.7.0",
     "tailwind-merge": "^3.4.0",
     "tailwindcss-animate": "^1.0.7",
+    "xlsx": "^0.18.5",
     "zod": "^4.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## 概要
申請データや承認履歴をCSV/Excel形式でエクスポートできる機能を追加

## 変更内容
- GET /api/export エンドポイントを新規作成
- /admin/export エクスポート管理ページを追加
- xlsx パッケージを追加

## 機能詳細
- エクスポート対象: 免許証/車検証/保険証/承認履歴/全データ
- ファイル形式: CSV（UTF-8 BOM付き）/ Excel（複数シート）
- 日付フィルター: 承認履歴の期間絞り込み
- 列幅自動調整

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)