### PR TITLE
feat: 一括承認機能を実装

### DIFF
--- a/app/api/approvals/bulk/route.ts
+++ b/app/api/approvals/bulk/route.ts
@@ -1,0 +1,296 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  approveDriversLicense,
+  getDriversLicenses,
+} from "@/services/drivers-license.service";
+import {
+  approveVehicleRegistration,
+  getVehicleRegistrations,
+} from "@/services/vehicle-registration.service";
+import {
+  approveInsurancePolicy,
+  getInsurancePolicies,
+} from "@/services/insurance-policy.service";
+import { requireAdmin, getCurrentUser } from "@/lib/auth-utils";
+import { getBaseRecords } from "@/lib/lark-client";
+import { LARK_TABLES, EMPLOYEE_FIELDS } from "@/lib/lark-tables";
+import { recordApprovalHistory } from "@/services/approval-history.service";
+import { getEmployee } from "@/services/employee.service";
+import {
+  createPermit,
+  revokeExistingPermit,
+} from "@/services/permit.service";
+import { generatePermitPdf } from "@/services/pdf-generator.service";
+import { calculatePermitExpiration } from "@/lib/permit-utils";
+
+// 最大一括承認件数
+const MAX_BULK_ITEMS = 50;
+
+interface BulkApprovalItem {
+  id: string;
+  type: "license" | "vehicle" | "insurance";
+}
+
+interface BulkApprovalRequest {
+  items: BulkApprovalItem[];
+  action: "approve" | "reject";
+  reason?: string; // 却下時のみ
+}
+
+interface BulkApprovalResult {
+  id: string;
+  type: string;
+  success: boolean;
+  error?: string;
+}
+
+/**
+ * 全書類が承認済みかチェックし、許可証を発行
+ */
+async function checkAndGeneratePermit(
+  employeeId: string,
+  baseUrl: string
+): Promise<void> {
+  try {
+    const licenses = await getDriversLicenses(employeeId);
+    const approvedLicense = licenses.find((l) => l.approval_status === "approved");
+    if (!approvedLicense) return;
+
+    const vehicles = await getVehicleRegistrations(employeeId);
+    const approvedVehicles = vehicles.filter((v) => v.approval_status === "approved");
+    if (approvedVehicles.length === 0) return;
+
+    const insurances = await getInsurancePolicies(employeeId);
+    const approvedInsurance = insurances.find((i) => i.approval_status === "approved");
+    if (!approvedInsurance) return;
+
+    const employee = await getEmployee(employeeId);
+    if (!employee) return;
+
+    for (const vehicle of approvedVehicles) {
+      try {
+        await revokeExistingPermit(vehicle.id);
+
+        const expirationDate = calculatePermitExpiration(
+          approvedLicense.expiration_date,
+          vehicle.inspection_expiration_date,
+          approvedInsurance.coverage_end_date
+        );
+
+        const permitData = {
+          employee_id: employeeId,
+          employee_name: employee.employee_name,
+          vehicle_id: vehicle.id,
+          vehicle_number: vehicle.vehicle_number,
+          vehicle_model: `${vehicle.manufacturer} ${vehicle.model_name}`,
+          expiration_date: expirationDate,
+        };
+
+        const permit = await createPermit(permitData, "");
+
+        const fileKey = await generatePermitPdf({
+          employeeName: employee.employee_name,
+          vehicleNumber: vehicle.vehicle_number,
+          vehicleModel: `${vehicle.manufacturer} ${vehicle.model_name}`,
+          issueDate: new Date(),
+          expirationDate,
+          permitId: permit.id,
+          verificationToken: permit.verification_token,
+          baseUrl,
+        });
+
+        const { updatePermitFileKey } = await import("@/services/permit.service");
+        await updatePermitFileKey(permit.id, fileKey);
+
+        console.log(`許可証を発行しました: ${employee.employee_name} - ${vehicle.vehicle_number}`);
+      } catch (error) {
+        console.error(`許可証発行エラー (車両: ${vehicle.id}):`, error);
+      }
+    }
+  } catch (error) {
+    console.error("許可証チェック・発行エラー:", error);
+  }
+}
+
+/**
+ * 従業員名を取得
+ */
+async function getEmployeeName(employeeId: string): Promise<string> {
+  try {
+    const employeesResponse = await getBaseRecords(LARK_TABLES.EMPLOYEES, {
+      filter: `CurrentValue.[${EMPLOYEE_FIELDS.employee_id}]="${employeeId}"`,
+    });
+    const employee = employeesResponse.data?.items?.[0];
+    if (employee) {
+      return String(employee.fields[EMPLOYEE_FIELDS.employee_name] || "不明");
+    }
+  } catch (error) {
+    console.error("Failed to get employee name:", error);
+  }
+  return "不明";
+}
+
+/**
+ * 単一の申請を承認
+ */
+async function approveSingleItem(
+  item: BulkApprovalItem,
+  currentUser: any,
+  baseUrl: string
+): Promise<BulkApprovalResult> {
+  try {
+    let applicationRecord: any = null;
+
+    switch (item.type) {
+      case "license":
+        const licenses = await getDriversLicenses();
+        applicationRecord = licenses.find((r) => r.id === item.id);
+        if (!applicationRecord) {
+          return { id: item.id, type: item.type, success: false, error: "Record not found" };
+        }
+        await approveDriversLicense(item.id);
+        break;
+      case "vehicle":
+        const vehicles = await getVehicleRegistrations();
+        applicationRecord = vehicles.find((r) => r.id === item.id);
+        if (!applicationRecord) {
+          return { id: item.id, type: item.type, success: false, error: "Record not found" };
+        }
+        await approveVehicleRegistration(item.id);
+        break;
+      case "insurance":
+        const insurances = await getInsurancePolicies();
+        applicationRecord = insurances.find((r) => r.id === item.id);
+        if (!applicationRecord) {
+          return { id: item.id, type: item.type, success: false, error: "Record not found" };
+        }
+        await approveInsurancePolicy(item.id);
+        break;
+      default:
+        return { id: item.id, type: item.type, success: false, error: "Invalid type" };
+    }
+
+    // 承認履歴を記録
+    if (applicationRecord) {
+      const employeeName = await getEmployeeName(applicationRecord.employee_id);
+
+      await recordApprovalHistory({
+        application_type: item.type,
+        application_id: item.id,
+        employee_id: applicationRecord.employee_id || "",
+        employee_name: employeeName,
+        action: "approved",
+        approver_id: currentUser.id || currentUser.email || "",
+        approver_name: currentUser.name || currentUser.email || "不明",
+        timestamp: Date.now(),
+      });
+
+      // 許可証の自動発行チェック
+      if (applicationRecord.employee_id) {
+        await checkAndGeneratePermit(applicationRecord.employee_id, baseUrl);
+      }
+    }
+
+    return { id: item.id, type: item.type, success: true };
+  } catch (error) {
+    console.error(`Error approving ${item.type} ${item.id}:`, error);
+    return {
+      id: item.id,
+      type: item.type,
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+}
+
+/**
+ * POST /api/approvals/bulk
+ * 複数の申請を一括承認（管理者のみ）
+ */
+export async function POST(request: NextRequest) {
+  // 管理者権限チェック
+  const authCheck = await requireAdmin();
+  if (!authCheck.authorized) {
+    return authCheck.response;
+  }
+
+  try {
+    const body: BulkApprovalRequest = await request.json();
+    const { items, action } = body;
+
+    // バリデーション
+    if (!items || !Array.isArray(items) || items.length === 0) {
+      return NextResponse.json(
+        { success: false, error: "No items provided" },
+        { status: 400 }
+      );
+    }
+
+    if (items.length > MAX_BULK_ITEMS) {
+      return NextResponse.json(
+        { success: false, error: `Maximum ${MAX_BULK_ITEMS} items allowed` },
+        { status: 400 }
+      );
+    }
+
+    if (action !== "approve" && action !== "reject") {
+      return NextResponse.json(
+        { success: false, error: "Invalid action. Use 'approve' or 'reject'" },
+        { status: 400 }
+      );
+    }
+
+    // 現在は承認のみサポート（却下は個別対応推奨）
+    if (action === "reject") {
+      return NextResponse.json(
+        { success: false, error: "Bulk rejection is not supported. Please reject individually with reason." },
+        { status: 400 }
+      );
+    }
+
+    const currentUser = await getCurrentUser();
+    if (!currentUser) {
+      return NextResponse.json(
+        { success: false, error: "User not found" },
+        { status: 401 }
+      );
+    }
+
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || request.nextUrl.origin;
+
+    // 並行処理で一括承認（最大10件ずつ）
+    const results: BulkApprovalResult[] = [];
+    const batchSize = 10;
+
+    for (let i = 0; i < items.length; i += batchSize) {
+      const batch = items.slice(i, i + batchSize);
+      const batchResults = await Promise.all(
+        batch.map((item) => approveSingleItem(item, currentUser, baseUrl))
+      );
+      results.push(...batchResults);
+    }
+
+    const successCount = results.filter((r) => r.success).length;
+    const failedCount = results.filter((r) => !r.success).length;
+
+    return NextResponse.json({
+      success: failedCount === 0,
+      message: `${successCount}件の承認が完了しました${failedCount > 0 ? `（${failedCount}件失敗）` : ""}`,
+      results,
+      summary: {
+        total: items.length,
+        success: successCount,
+        failed: failedCount,
+      },
+    });
+  } catch (error) {
+    console.error("Error in POST /api/approvals/bulk:", error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: "Failed to process bulk approval",
+      },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## 概要
管理者が複数の申請を一度に承認できる機能を追加

## 変更内容
- POST /api/approvals/bulk エンドポイントを新規作成
- 管理画面にチェックボックスと一括承認バーを追加

## 機能詳細
- 最大50件まで一括処理可能
- 全選択/全解除ボタン
- 選択件数のリアルタイム表示
- 選択中のカードをハイライト表示
- 並行処理（10件ずつバッチ）で効率的に処理

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)